### PR TITLE
Expose reference sources

### DIFF
--- a/sepp-package/run-sepp.sh
+++ b/sepp-package/run-sepp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash  
 
 if [ $# -lt 2 ]; then
-   echo USAGE: $0 "[input fragments file] [output prefix] [optional: -x number-of-cores ] [optional: -A alignment subset size] [optional: -P placement subset size] [optional: any other SEPP argument]
+   echo USAGE: $0 "[input fragments file] [output prefix] [optional: -x number-of-cores ] [optional: -A alignment subset size] [optional: -P placement subset size] [optional: any other SEPP argument] [optional: -t filename reference phylogeny] [optional: -a filename reference alignment]
    Optional commands need not be in order. Any SEPP option can also be passed. For example, use
    -x 8
    to make SEPP us 8 threads"
@@ -68,6 +68,14 @@ do
 			p="$2"
 			shift # past argument
 			;;
+		-a|--referenceAlignment)
+			alg="$2"
+			shift # past argument
+			;;
+		-t|--referencePhylogeny)
+			t="$2"
+			shift # past argument
+			;;
 		*)
 			opts="$opts"" ""$key"" ""$2"
 			shift # past argument
@@ -80,9 +88,15 @@ done
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # Reference tree
-t="$DIR/ref/reference-gg-raxml-bl-rooted-relabelled.tre"
+if [ -z $t ]; then
+	# resort to the default reference tree, if not specified via command line argument
+	t="$DIR/ref/reference-gg-raxml-bl-rooted-relabelled.tre"
+fi;
 # Reference alignment
-alg="$DIR/ref/gg_13_5_ssu_align_99_pfiltered.fasta"
+if [ -z $alg ]; then
+	# resort to the default reference alignment, if not specified via command line argument
+	alg="$DIR/ref/gg_13_5_ssu_align_99_pfiltered.fasta"
+fi;
 # RAxML info file generated when creating the reference RAxML tree
 rxi="$DIR/ref/RAxML_info-reference-gg-raxml-bl.info"
 


### PR DESCRIPTION
Hi Siavash,

for our use cases the reference alignment and tree should be exchangeable by the user. Therefore, I slightly updated your wrapper such that two additional optional arguments (-t and -a) can be passed that specify file location for the references. If arguments are not given, the wrapper falls back to the bundled reference files.

Would be great if you can merge that change in, we than would no longer need to patch this in for our applications.

Best,
Stefan