### PR TITLE
stop when placements are computed

### DIFF
--- a/sepp-package/run-sepp.sh
+++ b/sepp-package/run-sepp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash  
 
 if [ $# -lt 2 ]; then
-   echo USAGE: $0 "[input fragments file] [output prefix] [optional: -x number-of-cores ] [optional: -A alignment subset size] [optional: -P placement subset size] [optional: any other SEPP argument] [optional: -t filename reference phylogeny] [optional: -a filename reference alignment]
+   echo USAGE: $0 "[input fragments file] [output prefix] [optional: -x number-of-cores ] [optional: -A alignment subset size] [optional: -P placement subset size] [optional: any other SEPP argument] [optional: -t filename reference phylogeny] [optional: -a filename reference alignment] [optional: -n 1 = no tree-, just placements- computation]
    Optional commands need not be in order. Any SEPP option can also be passed. For example, use
    -x 8
    to make SEPP us 8 threads"
@@ -76,6 +76,10 @@ do
 			t="$2"
 			shift # past argument
 			;;
+		-n|--noTreeComputation)
+			noTree="$2"
+			shift # past argument
+			;;
 		*)
 			opts="$opts"" ""$key"" ""$2"
 			shift # past argument
@@ -111,14 +115,20 @@ cp -r $tmpssd $tmp;
 cp $tmp/${name}_placement.json .
 cp $tmp/${name}_rename-json.py .
 
-gbin=$( dirname `grep -A1 "pplacer" $DIR/sepp/.sepp/main.config |grep path|sed -e "s/^path=//g"` )
+# we might want to split computation in two parts: a) obtaining placements and b) creation of an insertion tree.
+# If -n set to something, we stop after a) and leave it to the user to compute b) afterwards.
+if [ -z ${noTree+x} ]; then
+	gbin=$( dirname `grep -A1 "pplacer" $DIR/sepp/.sepp/main.config |grep path|sed -e "s/^path=//g"` )
 
-$gbin/guppy tog ${name}_placement.json
+	$gbin/guppy tog ${name}_placement.json
 
-cat ${name}_placement.tog.tre | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.tre
+	cat ${name}_placement.tog.tre | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.tre
 
-$gbin/guppy tog --xml ${name}_placement.json
+	$gbin/guppy tog --xml ${name}_placement.json
 
-cat ${name}_placement.tog.xml | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.xml
+	cat ${name}_placement.tog.xml | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.xml
+else
+	echo "User requested skipping of insertion tree computation. Only placements are returned.";
+fi;
 
 echo output files are at ${name}_placement.* and more files are at $tmp . Consider removing $tmp if its files are not needed. 


### PR DESCRIPTION
Hi @smirarab ,

for Qiita and when distributing the workload via chunking the input fragments, we need to split a SEPP run into two parts: 1) computing placements, 2) taking placements and joining them into one tree via guppy.
It would be a waste of compute, if phase 1 would also run guppy if it is clear that the list of placements is incomplete (because we split the input fragments). Thus, it would be convenient to have a flag to indicate that only phase 1 needs to be computed.