### PR TITLE
Check id whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
+* Version 4.3.6:
+     * raise a ValueError if names of fragments to be inserted contain whitespace characters ' ' or '\t'.
 * Version 4.3.5:
      * raise a ValueError if names of fragments to be inserted collide with names of reference sequences.
 * Version 4.3.4:
      * Cleaning up the default (info) log  a bit
-* Version 4.3.3: 
+* Version 4.3.3:
      * avoid pipes for hmmsearch to deal with memory issues
      * Increase the default -F to 20000
 * Version 4.3.2: more fixes to UPP
@@ -11,7 +13,7 @@
      * degap input files when already aligned
      * avoid checking file names twice
 * Version 4.3.1: fixes to UPP
-     * In the absence of fragments, outputs are generated in a consistent fashion 
+     * In the absence of fragments, outputs are generated in a consistent fashion
      * PASTA alignment and trees are given a name prefixed by the output prefix naem
 * Version 4.3.0:
      * Added (Uyen Mai) an option -M and -S midpoint to break by midpoint and to stop by diameter

--- a/sepp/__init__.py
+++ b/sepp/__init__.py
@@ -22,7 +22,7 @@ import os
 
 __all__ = ["alignment", "shortreadalignment", "taxonneighbourfinder", "tools", "problem"]
 
-version = "4.3.5"
+version = "4.3.6"
 
 _DEBUG = "SEPP_DEBUG" in os.environ and os.environ["SEPP_DEBUG"].lower() == "true"
 #print "Debug mode is %s." %("on" if _DEBUG else "off")

--- a/sepp/algorithm.py
+++ b/sepp/algorithm.py
@@ -259,6 +259,22 @@ class AbstractAlgorithm(object):
                 "ut fragments and re-start. Duplicate names are:\n  '%s'") %
                 (len(ids_overlap), "'\n  '".join(ids_overlap)))
 
+        # test if input fragment names contain whitespaces / tabs which would
+        # cause hmmsearch to fail.
+        # code contribution by Stefan Janssen (June 22nd, 2018)
+        ids_inputfragments_spaces = [
+            id_
+            for id_ in ids_inputfragments
+            if (' ' in id_) or ('\t' in id_)]
+        if len(ids_inputfragments_spaces) > 0:
+            raise ValueError((
+                "Your input fragment file contains %i sequences, whose names "
+                "contain either whitespaces: ' ' or tabulator '\\t' symbols. "
+                "Please rename your input fragments and re-start. Affected "
+                "names are:\n  '%s'") %
+                (len(ids_inputfragments_spaces),
+                 "'\n  '".join(ids_inputfragments_spaces)))
+
         for (k,v) in extra_frags.items():
             self.root_problem.fragments[k] = v.replace("-","")
         alg_chunks = self.root_problem.fragments.divide_to_equal_chunks(chunks, max_chunk_size)        

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from distutils.core import setup, Command
 from distutils.command.install import install
 from distutils.spawn import find_executable
 
-version = "4.3.5"
+version = "4.3.6"
     
 def get_tools_dir(where):
     platform_name = platform.system()

--- a/test/unittest/testSepp.py
+++ b/test/unittest/testSepp.py
@@ -48,6 +48,15 @@ class Test(unittest.TestCase):
             self.x.run()
         self.assertTrue(self.x.results is None)
 
+    def test_seqnames_whitespaces(self):
+        self.x.options.fragment_file = open(
+            "data/q2-fragment-insertion/input_fragments_spaces.fasta", "r")
+        with self.assertRaisesRegex(
+                ValueError,
+                "contain either whitespaces: "):
+            self.x.run()
+        self.assertTrue(self.x.results is None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@wasade encountered the use case of fragment names containing white spaces (or tabs). This PR will address the issue by raising a ValueError if those cases are detected early on.