### PR TITLE
Rel file paths

### DIFF
--- a/sepp/filemgr.py
+++ b/sepp/filemgr.py
@@ -30,6 +30,7 @@ File and path management.
 
 import os
 import shutil
+import inspect
 
 _LOG = get_logger(__name__)
 
@@ -159,3 +160,36 @@ def directory_has_files_with_prefix(d, prefix):
         if (re.search('^' + prefix + '.*', f) is not None):
             return True
     return False
+
+
+# copy and paste from https://github.com/biocore/scikit-bio/blob/
+# aa502f9dbc7670cf1f8feb6777f6abf181deadc5/skbio/util/_testing.py#L49
+def get_data_path(fn, subfolder='data'):
+    """Return path to filename ``fn`` in the data folder.
+    During testing it is often necessary to load data files. This
+    function returns the full path to files in the ``data`` subfolder
+    by default.
+    Parameters
+    ----------
+    fn : str
+        File name.
+    subfolder : str, defaults to ``data``
+        Name of the subfolder that contains the data.
+    Returns
+    -------
+    str
+        Inferred absolute path to the test data for the module where
+        ``get_data_path(fn)`` is called.
+    Notes
+    -----
+    The requested path may not point to an existing file, as its
+    existence is not checked.
+    """
+    # getouterframes returns a list of tuples: the second tuple
+    # contains info about the caller, and the second element is its
+    # filename
+    callers_filename = inspect.getouterframes(inspect.currentframe())[1][1]
+    path = os.path.dirname(os.path.abspath(callers_filename))
+    data_path = os.path.join(path, subfolder, fn)
+
+    return data_path

--- a/sepp/math_utils.py
+++ b/sepp/math_utils.py
@@ -3,8 +3,6 @@ Created on Nov 14, 2012
 
 @author: smirarab
 '''
-import inspect
-import os
 
 
 def gcd(a, b):
@@ -17,36 +15,3 @@ def gcd(a, b):
 def lcm(a, b):
     """Return lowest common multiple."""
     return a * b // gcd(a, b)
-
-
-# copy and paste from https://github.com/biocore/scikit-bio/blob/
-# aa502f9dbc7670cf1f8feb6777f6abf181deadc5/skbio/util/_testing.py#L49
-def get_data_path(fn, subfolder='data'):
-    """Return path to filename ``fn`` in the data folder.
-    During testing it is often necessary to load data files. This
-    function returns the full path to files in the ``data`` subfolder
-    by default.
-    Parameters
-    ----------
-    fn : str
-        File name.
-    subfolder : str, defaults to ``data``
-        Name of the subfolder that contains the data.
-    Returns
-    -------
-    str
-        Inferred absolute path to the test data for the module where
-        ``get_data_path(fn)`` is called.
-    Notes
-    -----
-    The requested path may not point to an existing file, as its
-    existence is not checked.
-    """
-    # getouterframes returns a list of tuples: the second tuple
-    # contains info about the caller, and the second element is its
-    # filename
-    callers_filename = inspect.getouterframes(inspect.currentframe())[1][1]
-    path = os.path.dirname(os.path.abspath(callers_filename))
-    data_path = os.path.join(path, subfolder, fn)
-
-    return data_path

--- a/sepp/math_utils.py
+++ b/sepp/math_utils.py
@@ -3,6 +3,8 @@ Created on Nov 14, 2012
 
 @author: smirarab
 '''
+import inspect
+import os
 
 
 def gcd(a, b):
@@ -15,3 +17,36 @@ def gcd(a, b):
 def lcm(a, b):
     """Return lowest common multiple."""
     return a * b // gcd(a, b)
+
+
+# copy and paste from https://github.com/biocore/scikit-bio/blob/
+# aa502f9dbc7670cf1f8feb6777f6abf181deadc5/skbio/util/_testing.py#L49
+def get_data_path(fn, subfolder='data'):
+    """Return path to filename ``fn`` in the data folder.
+    During testing it is often necessary to load data files. This
+    function returns the full path to files in the ``data`` subfolder
+    by default.
+    Parameters
+    ----------
+    fn : str
+        File name.
+    subfolder : str, defaults to ``data``
+        Name of the subfolder that contains the data.
+    Returns
+    -------
+    str
+        Inferred absolute path to the test data for the module where
+        ``get_data_path(fn)`` is called.
+    Notes
+    -----
+    The requested path may not point to an existing file, as its
+    existence is not checked.
+    """
+    # getouterframes returns a list of tuples: the second tuple
+    # contains info about the caller, and the second element is its
+    # filename
+    callers_filename = inspect.getouterframes(inspect.currentframe())[1][1]
+    path = os.path.dirname(os.path.abspath(callers_filename))
+    data_path = os.path.join(path, subfolder, fn)
+
+    return data_path

--- a/test/unittest/data/configs/test2.config
+++ b/test/unittest/data/configs/test2.config
@@ -5,3 +5,9 @@ placementSize = 10
 
 [pplacer]
 path=pplacer
+
+[hmmalign]
+path=hmmalign
+
+[hmmsearch]
+path=hmmsearch

--- a/test/unittest/data/configs/test2.config
+++ b/test/unittest/data/configs/test2.config
@@ -1,6 +1,6 @@
 [commandline]
 placementSize = 10 
-alignment = data/simulated/test.small.fas
+#alignment = data/simulated/test.small.fas
 #raxml = data/simulated/test.small.fas
 
 [pplacer]

--- a/test/unittest/testAlignment.py
+++ b/test/unittest/testAlignment.py
@@ -8,6 +8,7 @@ import sepp
 from sepp.alignment import MutableAlignment, ReadonlySubalignment,\
     ExtendedAlignment
 from sepp.problem import SeppProblem
+from sepp.math_utils import get_data_path
 
 
 sepp._DEBUG = True
@@ -23,7 +24,7 @@ class Test(unittest.TestCase):
 
     def testAlignmentReadFasta(self):
         alg = MutableAlignment()
-        alg.read_filepath("data/mock/pyrg/sate.fasta")
+        alg.read_filepath(get_data_path("mock/pyrg/sate.fasta"))
 
         assert len(alg) == 65, "MutableAlignment length is %s" % len(alg)
 
@@ -31,7 +32,7 @@ class Test(unittest.TestCase):
 
     def testReadOnlySubAlignment(self):
         alg = MutableAlignment()
-        alg.read_filepath("data/mock/pyrg/sate.fasta")
+        alg.read_filepath(get_data_path("mock/pyrg/sate.fasta"))
 
         subset = ['NC_008701_720717_722309', 'NC_013156_149033_150643',
                   'NC_013887_802739_801129']
@@ -66,7 +67,8 @@ class Test(unittest.TestCase):
         assert readonly_subalignment.is_all_gap(150) is False, \
             "Site 100 should not be all gaps"
 
-        readonly_subalignment.write_to_path("data/mock/pyrg/sate.sub.fasta")
+        readonly_subalignment.write_to_path(get_data_path(
+            "mock/pyrg/sate.sub.fasta"))
 
         mutable_subalignment = readonly_subalignment.get_mutable_alignment()
         mutable_subalignment.delete_all_gap()
@@ -91,12 +93,12 @@ class Test(unittest.TestCase):
             "SBDF", "SGBJ", "SDHE", "SJIB", "SHHI", "SIDE", "SJII"]
 
         alg = MutableAlignment()
-        alg.read_filepath("data/simulated/test.fasta")
+        alg.read_filepath(get_data_path("simulated/test.fasta"))
         alg.delete_all_gap()
         tlen = alg.get_length()
 
         frg = MutableAlignment()
-        frg.read_filepath("data/simulated/test.fas")
+        frg.read_filepath(get_data_path("simulated/test.fas"))
         # print frg.get_num_taxa()
 
         pp = SeppProblem(list(alg.keys()))
@@ -111,36 +113,38 @@ class Test(unittest.TestCase):
             [k for k in list(frg.keys()) if int(k[-1]) <= 1], frg)
 
         cp1labels = cp1.write_subalignment_without_allgap_columns(
-            "data/tmp/cp1.fasta")
+            get_data_path("tmp/cp1.fasta"))
         cp2labels = cp2.write_subalignment_without_allgap_columns(
-            "data/tmp/cp2.fasta")
-        tmp = MutableAlignment().read_filepath("data/tmp/cp1.fasta")
+            get_data_path("tmp/cp2.fasta"))
+        tmp = MutableAlignment().read_filepath(get_data_path("tmp/cp1.fasta"))
         assert all([not tmp.is_all_gap(pos)
                     for pos in range(0, tmp.get_length())])
-        tmp = MutableAlignment().read_filepath("data/tmp/cp2.fasta")
+        tmp = MutableAlignment().read_filepath(get_data_path("tmp/cp2.fasta"))
         assert all([not tmp.is_all_gap(pos)
                     for pos in range(0, tmp.get_length())])
 
-        cp1.fragments.write_to_path("data/tmp/cp1.frags.fas")
-        cp2.fragments.write_to_path("data/tmp/cp2.frags.fas")
+        cp1.fragments.write_to_path(get_data_path("tmp/cp1.frags.fas"))
+        cp2.fragments.write_to_path(get_data_path("tmp/cp2.frags.fas"))
 
         '''We have done the hmmalign before.
            don't worry about that right now'''
 
         ext1 = ExtendedAlignment(cp1.fragments)
         ext1.build_extended_alignment(
-            "data/tmp/cp1.fasta", "data/tmp/cp1.extended.sto")
+            get_data_path("tmp/cp1.fasta"),
+            get_data_path("tmp/cp1.extended.sto"))
         ext1.relabel_original_columns(cp1labels)
         ext2 = ExtendedAlignment(cp2.fragments)
         ext2.build_extended_alignment(
-            "data/tmp/cp2.fasta", "data/tmp/cp2.extended.sto")
+            get_data_path("tmp/cp2.fasta"),
+            get_data_path("tmp/cp2.extended.sto"))
         ext2.relabel_original_columns(cp2labels)
 
         extmerger = ExtendedAlignment([])
         extmerger.merge_in(ext1)
         mixed = extmerger.merge_in(ext2)
 
-        extmerger.write_to_path("data/tmp/extended.merged.fasta")
+        extmerger.write_to_path(get_data_path("tmp/extended.merged.fasta"))
 
         assert extmerger.is_aligned(), "Merged alignment is not aligned"
         in1 = len([x for x in ext1._col_labels if x < 0])

--- a/test/unittest/testAlignment.py
+++ b/test/unittest/testAlignment.py
@@ -8,7 +8,7 @@ import sepp
 from sepp.alignment import MutableAlignment, ReadonlySubalignment,\
     ExtendedAlignment
 from sepp.problem import SeppProblem
-from sepp.math_utils import get_data_path
+from sepp.filemgr import get_data_path
 
 
 sepp._DEBUG = True

--- a/test/unittest/testConfig.py
+++ b/test/unittest/testConfig.py
@@ -14,7 +14,7 @@ try:
     filetypes = (io.IOBase, file)
 except NameError:
     filetypes = io.IOBase
-from sepp.math_utils import get_data_path
+from sepp.filemgr import get_data_path
 from tempfile import mkstemp
 
 

--- a/test/unittest/testConfig.py
+++ b/test/unittest/testConfig.py
@@ -88,36 +88,39 @@ class Test(unittest.TestCase):
         # Just to make different test cases independent of each other.
         config._options_singelton = None
 
-        sys.argv = [sys.argv[0], "-c", get_data_path("configs/test.config")]
-        print("STEFAN", options().pplacer.path)
+        sys.argv = [sys.argv[0], "-c", get_data_path("configs/test2.config")]
+        # set pplacer filepath to a file shipped with the code base
+        options().pplacer.path = get_data_path(
+            "../../../tools/bundled/Darwin/pplacer")
+
         assert (options().pplacer is not None and os.path.exists(
                 options().pplacer.path)), \
             ("main config file options not read properly,"
              "or nonexistent binaries: pplacer = %s" %
              options().pplacer.path)
 
-        # assert (options().hmmalign is not None and os.path.exists(
-        #         options().hmmalign.path)), \
-        #     ("main config file options not read properly, or nonexistent "
-        #      "binaries: hmmalign = %s" % options().pplacer.path)
-        #
-        # assert (options().hmmsearch is not None and os.path.exists(
-        #         options().hmmalign.path)), \
-        #     ("main config file options not read properly, or nonexistent "
-        #      "binaries: hmmsearch = %s" % options().pplacer.path)
-    #
-    # def testCpuCount(self):
-    #     # Just to make different test cases independent of each other.
-    #     config._options_singelton = None
-    #     back = config.main_config_path
-    #     # Diasable main config path for this test
-    #     config.main_config_path = os.path.expanduser(
-    #         "~/.sepp/main.config.notexistentfile")
-    #     sys.argv = [sys.argv[0], "-x", "7"]
-    #
-    #     assert options().cpu == 7, "Commandline option -x not read properly"
-    #
-    #     config.main_config_path = back
+        options().hmmalign.path = get_data_path(
+            "../../../tools/bundled/Darwin/hmmalign")
+        assert (options().hmmalign is not None and os.path.exists(
+                options().hmmalign.path)), \
+            ("main config file options not read properly, or nonexistent "
+             "binaries: hmmalign = %s" % options().hmmalign.path)
+
+        options().hmmsearch.path = get_data_path(
+            "../../../tools/bundled/Darwin/hmmsearch")
+        assert (options().hmmsearch is not None and os.path.exists(
+                options().hmmsearch.path)), \
+            ("main config file options not read properly, or nonexistent "
+             "binaries: hmmsearch = %s" % options().hmmsearch.path)
+
+    def testCpuCount(self):
+        # Just to make different test cases independent of each other.
+        config._options_singelton = None
+        # Diasable main config path for this test
+        config.main_config_path = self.fp_config
+        sys.argv = [sys.argv[0], "-x", "7"]
+
+        assert options().cpu == 7, "Commandline option -x not read properly"
 
 
 if __name__ == "__main__":

--- a/test/unittest/testConfig.py
+++ b/test/unittest/testConfig.py
@@ -14,24 +14,35 @@ try:
     filetypes = (io.IOBase, file)
 except NameError:
     filetypes = io.IOBase
+from sepp.math_utils import get_data_path
+from tempfile import mkstemp
 
 
 class Test(unittest.TestCase):
+    fp_config = None
+
+    def setUp(self):
+        _, self.fp_config = mkstemp()
+
+    def tearDown(self):
+        os.remove(self.fp_config)
+
     def testConfigFile(self):
         # Just to make different test cases independent of each other.
         config._options_singelton = None
-        back = config.main_config_path
         # Diasable main config path for this test
-        config.main_config_path = os.path.expanduser(
-            "~/.sepp/main.config.notexistentfile")
-        sys.argv = [sys.argv[0], "-A", "2", "-c", "data/configs/test.config",
-                    "--outdir", "dir_form_commandline"]
+        config.main_config_path = self.fp_config
+
+        sys.argv = [
+            sys.argv[0], "-A", "2",
+            "-c", get_data_path("configs/test.config"),
+            "--outdir", "dir_form_commandline"]
 
         assert options().alignment_size == 2, \
             "Commandline option -A not read properly"
 
-        assert isinstance(options().config_file, filetypes) \
-            and options().config_file.name == "data/configs/test.config", \
+        assert isinstance(options().config_file, filetypes) and \
+            options().config_file.name.endswith("data/configs/test.config"), \
             "Commandline option -c not read properly"
 
         assert (options().pplacer is not None
@@ -48,67 +59,65 @@ class Test(unittest.TestCase):
         assert options().tempdir is not None, \
             "Default value not properly set for tempfile attribute"
 
-        config.main_config_path = back
-
     def testConfigFileMissingFile(self):
         # Just to make different test cases independent of each other.
         config._options_singelton = None
-        back = config.main_config_path
         # Diasable main config path for this test
-        config.main_config_path = os.path.expanduser(
-            "~/.sepp/main.config.notexistentfile")
+        config.main_config_path = self.fp_config
 
-        sys.argv = [sys.argv[0], "-c", "data/configs/test2.config", "-f",
-                    "data/simulated/test.fas"]
-        assert isinstance(options().config_file, filetypes) \
-            and options().config_file.name == "data/configs/test2.config", \
+        sys.argv = [sys.argv[0],
+                    "-c", get_data_path("configs/test2.config"),
+                    "-f", get_data_path("simulated/test.fas"),
+                    "-a", get_data_path("simulated/test.small.fas")]
+        assert isinstance(options().config_file, filetypes) and \
+            options().config_file.name.endswith(
+                "data/configs/test2.config"), \
             "Commandline option -c not read properly"
 
-        assert isinstance(options().alignment_file, filetypes) \
-            and options().alignment_file.name == \
-            "data/simulated/test.small.fas", \
+        assert isinstance(options().alignment_file, filetypes) and\
+            options().alignment_file.name.endswith(
+                "data/simulated/test.small.fas"), \
             "Config file option alignment not read properly"
 
-        assert isinstance(options().fragment_file, filetypes) \
-            and options().fragment_file.name == "data/simulated/test.fas", \
+        assert isinstance(options().fragment_file, filetypes) and\
+            options().fragment_file.name.endswith(
+                "data/simulated/test.fas"), \
             "Command-line option -f alignment not read properly"
-
-        config.main_config_path = back
 
     def testMainConfigFile(self):
         # Just to make different test cases independent of each other.
         config._options_singelton = None
 
-        sys.argv = [sys.argv[0]]
-
+        sys.argv = [sys.argv[0], "-c", get_data_path("configs/test.config")]
+        print("STEFAN", options().pplacer.path)
         assert (options().pplacer is not None and os.path.exists(
                 options().pplacer.path)), \
             ("main config file options not read properly,"
              "or nonexistent binaries: pplacer = %s" %
              options().pplacer.path)
 
-        assert (options().hmmalign is not None and os.path.exists(
-                options().hmmalign.path)), \
-            ("main config file options not read properly, or nonexistent "
-             "binaries: hmmalign = %s" % options().pplacer.path)
-
-        assert (options().hmmsearch is not None and os.path.exists(
-                options().hmmalign.path)), \
-            ("main config file options not read properly, or nonexistent "
-             "binaries: hmmsearch = %s" % options().pplacer.path)
-
-    def testCpuCount(self):
-        # Just to make different test cases independent of each other.
-        config._options_singelton = None
-        back = config.main_config_path
-        # Diasable main config path for this test
-        config.main_config_path = os.path.expanduser(
-            "~/.sepp/main.config.notexistentfile")
-        sys.argv = [sys.argv[0], "-x", "7"]
-
-        assert options().cpu == 7, "Commandline option -x not read properly"
-
-        config.main_config_path = back
+        # assert (options().hmmalign is not None and os.path.exists(
+        #         options().hmmalign.path)), \
+        #     ("main config file options not read properly, or nonexistent "
+        #      "binaries: hmmalign = %s" % options().pplacer.path)
+        #
+        # assert (options().hmmsearch is not None and os.path.exists(
+        #         options().hmmalign.path)), \
+        #     ("main config file options not read properly, or nonexistent "
+        #      "binaries: hmmsearch = %s" % options().pplacer.path)
+    #
+    # def testCpuCount(self):
+    #     # Just to make different test cases independent of each other.
+    #     config._options_singelton = None
+    #     back = config.main_config_path
+    #     # Diasable main config path for this test
+    #     config.main_config_path = os.path.expanduser(
+    #         "~/.sepp/main.config.notexistentfile")
+    #     sys.argv = [sys.argv[0], "-x", "7"]
+    #
+    #     assert options().cpu == 7, "Commandline option -x not read properly"
+    #
+    #     config.main_config_path = back
 
 
 if __name__ == "__main__":

--- a/test/unittest/testExternalJobs.py
+++ b/test/unittest/testExternalJobs.py
@@ -69,7 +69,7 @@ class Test(unittest.TestCase):
 
         find_job = TestExternalJob()
         find_job.pattern = ".."
-        find_job.options = "-name %s" % res0.replace("./test", "*")
+        find_job.options = "-name %s" % res0.split('/')[-1]
         JobPool().enqueue_job(find_job)
 
         JobPool().wait_for_all_jobs()
@@ -78,7 +78,7 @@ class Test(unittest.TestCase):
 
         assert res1 != ""
 
-        assert res1.replace("../unittest/", "./") == res0
+        assert res1.endswith(res0[2:])
 
     def testError(self):
         find_job = TestExternalJob()

--- a/test/unittest/testMerge.py
+++ b/test/unittest/testMerge.py
@@ -6,14 +6,19 @@ Created on Nov 20, 2012
 import unittest
 from sepp.jobs import MergeJsonJob
 import sys
+import os.path
+from sepp.math_utils import get_data_path
 
 
 class Test(unittest.TestCase):
     def testMerge(self):
         sys.argv = [sys.argv[0]]
-        stdindata = open("data/tmp/tempmerge").read()
+        stdindata = open(get_data_path("tmp/tempmerge")).read()
         mergeJsonJob = MergeJsonJob()
-        mergeJsonJob.setup(stdindata, "data/tmp/mergedfile")
+        mergeJsonJob.setup(stdindata.replace(
+            'data/tmp/pplacer.extended',
+            os.path.dirname(get_data_path("tmp/tempmerge")) +
+            '/pplacer.extended'), get_data_path("tmp/mergedfile"))
         mergeJsonJob.run()
 
 

--- a/test/unittest/testMerge.py
+++ b/test/unittest/testMerge.py
@@ -7,7 +7,7 @@ import unittest
 from sepp.jobs import MergeJsonJob
 import sys
 import os.path
-from sepp.math_utils import get_data_path
+from sepp.filemgr import get_data_path
 
 
 class Test(unittest.TestCase):

--- a/test/unittest/testSepp.py
+++ b/test/unittest/testSepp.py
@@ -7,7 +7,7 @@ import tempfile
 import shutil
 import unittest
 import sepp
-from sepp.math_utils import get_data_path
+from sepp.filemgr import get_data_path
 
 from sepp.exhaustive import ExhaustiveAlgorithm
 sepp._DEBUG = True

--- a/test/unittest/testSepp.py
+++ b/test/unittest/testSepp.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 import unittest
 import sepp
+from sepp.math_utils import get_data_path
 
 from sepp.exhaustive import ExhaustiveAlgorithm
 sepp._DEBUG = True
@@ -18,12 +19,15 @@ class Test(unittest.TestCase):
     def setUp(self):
         self.x = ExhaustiveAlgorithm()
         self.x.options.alignment_file = open(
-            "data/q2-fragment-insertion/reference_alignment_tiny.fasta", "r")
+            get_data_path(
+                "q2-fragment-insertion/reference_alignment_tiny.fasta"), "r")
         self.x.options.info_file = open(
-            "data/q2-fragment-insertion/RAxML_info-reference-gg-raxml-bl.info",
+            get_data_path(
+                "q2-fragment-insertion/RAxML_info-reference-gg-raxml-bl.info"),
             "r")
         self.x.options.tree_file = open(
-            "data/q2-fragment-insertion/reference_phylogeny_tiny.nwk", "r")
+            get_data_path(
+                "q2-fragment-insertion/reference_phylogeny_tiny.nwk"), "r")
         self.x.options.outdir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -35,13 +39,15 @@ class Test(unittest.TestCase):
 
     def test_id_collision_working(self):
         self.x.options.fragment_file = open(
-            "data/q2-fragment-insertion/input_fragments.fasta", "r")
+            get_data_path(
+                "q2-fragment-insertion/input_fragments.fasta"), "r")
         self.x.run()
         self.assertTrue(self.x.results is not None)
 
     def test_id_collision_collision(self):
         self.x.options.fragment_file = open(
-            "data/q2-fragment-insertion/input_fragments_collide.fasta", "r")
+            get_data_path(
+                "q2-fragment-insertion/input_fragments_collide.fasta"), "r")
         with self.assertRaisesRegex(
                 ValueError,
                 ' whose names overlap with names in your reference'):
@@ -50,7 +56,8 @@ class Test(unittest.TestCase):
 
     def test_seqnames_whitespaces(self):
         self.x.options.fragment_file = open(
-            "data/q2-fragment-insertion/input_fragments_spaces.fasta", "r")
+            get_data_path(
+                "q2-fragment-insertion/input_fragments_spaces.fasta"), "r")
         with self.assertRaisesRegex(
                 ValueError,
                 "contain either whitespaces: "):


### PR DESCRIPTION
these changes to the unit tests allow to execute them from whatever directory, since file paths are no longer absolute.
This is needed to support "nosetests", which in turn can report coverage information.