### PR TITLE
Enable nosetests

### DIFF
--- a/test/unittest/TestFork.py
+++ b/test/unittest/TestFork.py
@@ -9,6 +9,7 @@ import sys
 import os
 from multiprocessing import Lock
 import time
+import unittest
 
 
 class TestJob(Job):
@@ -68,7 +69,7 @@ class TestJob(Job):
 
 s = 0
 lock = Lock()
-if __name__ == '__main__':
+def run():
     global pool
     pool1 = JobPool(2)
     pool2 = JobPool()
@@ -123,3 +124,12 @@ if __name__ == '__main__':
         "Parallelization Error, what happened to the rest?"
 
     print("Everything seems fine!")
+
+
+class Test(unittest.TestCase):
+    def test_me(self):
+        run()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unittest/TestFork.py
+++ b/test/unittest/TestFork.py
@@ -4,6 +4,7 @@ Created on Aug 22, 2012
 @author: smirarab
 '''
 from sepp.scheduler import Job, JobPool
+from multiprocessing import cpu_count
 from random import random
 import sys
 import os
@@ -23,7 +24,7 @@ class TestJob(Job):
         self.state = None
 
         def add_a_child(parent):
-            print("Adding a child job for %s" % (parent), file=sys.stderr)
+            # print("Adding a child job for %s" % (parent), file=sys.stderr)
             JobPool().enqueue_job(TestJob("%s.child" % parent))
             # print "Added a child for: ",parent
 
@@ -42,14 +43,14 @@ class TestJob(Job):
 
     def print_res(self, result):
         global s
-        print("%s returned: %d" % (self.jobname, self.result))
+        # print("%s returned: %d" % (self.jobname, self.result))
         lock.acquire()
         s -= 1
         lock.release()
 
     def run(self):
-        print("Process [%s]: running %s" % (os.getpid(), self.jobname),
-              file=sys.stderr)
+        # print("Process [%s]: running %s" % (os.getpid(), self.jobname),
+        #       file=sys.stderr)
         # Adding the following line results in a failure:
         # AssertionError: daemonic processes are not allowed to have children.
         # This is expected because the new process is going to try to start a
@@ -69,6 +70,8 @@ class TestJob(Job):
 
 s = 0
 lock = Lock()
+
+
 def run():
     global pool
     pool1 = JobPool(2)
@@ -101,7 +104,7 @@ def run():
         assert(jobs[3].result_set is False)
 
     errors = pool.get_all_job_errors()
-    print("Following job errors were raised:", errors)
+    # print("Following job errors were raised:", errors)
 
     try:
         pool.wait_for_all_jobs(ignore_error=False)
@@ -110,7 +113,7 @@ def run():
 
     errs = [pool.get_job_error(job) for job in pool.get_failed_jobs()]
 
-    print(errs)
+    # print(errs)
 
     assert len(errs) == len(errors), \
         "Number of errors from failed jobs: %d. Number of errors: %d" % \
@@ -118,15 +121,20 @@ def run():
     assert False not in [x in errors for x in errs]
 
     # print [job.state for job in jobs]
-    print("Number of started jobs - number of printed results:", s)
-    print("Number of failed jobs:", len(errors))
+    # print("Number of started jobs - number of printed results:", s)
+    # print("Number of failed jobs:", len(errors))
     assert s == len(errors), \
         "Parallelization Error, what happened to the rest?"
 
-    print("Everything seems fine!")
+    # print("Everything seems fine!")
 
 
 class Test(unittest.TestCase):
+    def tearDown(self):
+        # clean up JobPool for other unit tests
+        JobPool().terminate()
+        JobPool().__init__(cpu_count())
+
     def test_me(self):
         run()
 

--- a/test/unittest/TestForkJoin.py
+++ b/test/unittest/TestForkJoin.py
@@ -12,8 +12,9 @@ from sepp.scheduler import Job, JobPool, Join
 from random import random
 import sys
 import os
-from multiprocessing import Lock
+from multiprocessing import Lock, cpu_count
 from sepp.problem import Problem
+import unittest
 
 
 # Depth of problem hierarchy (for decomposition). Tips are equivalent
@@ -377,7 +378,13 @@ def build_job_dag(root_problem):
 
 s = 0
 lock = Lock()
-if __name__ == '__main__':
+root_problem = None
+
+
+def run():
+    global root_problem
+    JobPool().terminate()
+    JobPool().__init__(2)
     pool = JobPool(2)
 
     '''build the problem structure'''
@@ -405,3 +412,17 @@ if __name__ == '__main__':
         print(trimstr(problem.get_job_result_by_name("buildmodel")),
               trimstr(problem.get_job_result_by_name("summarize")))
     # print [str(x) for x in root_problem.iter_leaves()]
+
+
+class Test(unittest.TestCase):
+    def tearDown(self):
+        # clean up JobPool for other unit tests
+        JobPool().terminate()
+        JobPool().__init__(cpu_count())
+
+    def test_me(self):
+        run()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unittest/data/configs/test2.config
+++ b/test/unittest/data/configs/test2.config
@@ -1,5 +1,5 @@
 [commandline]
-placementSize = 10 
+placementSize = 10
 #alignment = data/simulated/test.small.fas
 #raxml = data/simulated/test.small.fas
 
@@ -11,3 +11,10 @@ path=hmmalign
 
 [hmmsearch]
 path=hmmsearch
+
+[exhaustive]
+strategy = centroid
+minsubsetsize = 20
+placementminsubsetsizefacotr = 4
+placer = pplacer
+weight_placement_by_alignment = True

--- a/test/unittest/testAlignment.py
+++ b/test/unittest/testAlignment.py
@@ -9,12 +9,10 @@ from sepp.alignment import MutableAlignment, ReadonlySubalignment,\
     ExtendedAlignment
 from sepp.problem import SeppProblem
 from sepp.filemgr import get_data_path
-import logging
 from tempfile import mkstemp
 from os import remove
 
 
-logging.disable(logging.INFO)
 sepp._DEBUG = True
 
 

--- a/test/unittest/testAlignment.py
+++ b/test/unittest/testAlignment.py
@@ -14,7 +14,7 @@ from tempfile import mkstemp
 from os import remove
 
 
-logging.disable(logging.CRITICAL)
+logging.disable(logging.INFO)
 sepp._DEBUG = True
 
 

--- a/test/unittest/testConfig.py
+++ b/test/unittest/testConfig.py
@@ -19,7 +19,7 @@ from tempfile import mkstemp
 import logging
 
 
-logging.disable(logging.CRITICAL)
+logging.disable(logging.INFO)
 
 class Test(unittest.TestCase):
     fp_config = None

--- a/test/unittest/testConfig.py
+++ b/test/unittest/testConfig.py
@@ -16,10 +16,9 @@ except NameError:
     filetypes = io.IOBase
 from sepp.filemgr import get_data_path
 from tempfile import mkstemp
-import logging
+from sepp.scheduler import Job, JobPool
+from multiprocessing import cpu_count
 
-
-logging.disable(logging.INFO)
 
 class Test(unittest.TestCase):
     fp_config = None
@@ -119,11 +118,22 @@ class Test(unittest.TestCase):
     def testCpuCount(self):
         # Just to make different test cases independent of each other.
         config._options_singelton = None
-        # Diasable main config path for this test
+        # Disable main config path for this test
         config.main_config_path = self.fp_config
+        JobPool().terminate()
+        JobPool().__init__(7)
         sys.argv = [sys.argv[0], "-x", "7"]
 
         assert options().cpu == 7, "Commandline option -x not read properly"
+
+        # clean up after test:
+        # 1) the JobPool CPU counts needs to be reset to the default
+        # 2) the command line arguments must be restored
+        JobPool().terminate()
+        JobPool().__init__(cpu_count())
+        sys.argv = [sys.argv[0], "-x", str(cpu_count())]
+        config._options_singelton = None
+        options()
 
 
 if __name__ == "__main__":

--- a/test/unittest/testConfig.py
+++ b/test/unittest/testConfig.py
@@ -16,7 +16,10 @@ except NameError:
     filetypes = io.IOBase
 from sepp.filemgr import get_data_path
 from tempfile import mkstemp
+import logging
 
+
+logging.disable(logging.CRITICAL)
 
 class Test(unittest.TestCase):
     fp_config = None

--- a/test/unittest/testExternalJobs.py
+++ b/test/unittest/testExternalJobs.py
@@ -6,9 +6,15 @@ Created on Oct 2, 2012
 import unittest
 from sepp.jobs import ExternalSeppJob
 from sepp.scheduler import JobPool, JobError
+from multiprocessing import cpu_count
 
 
 class TestExternalJob(ExternalSeppJob):
+    def tearDown(self):
+        # clean up JobPool for other unit tests
+        JobPool().terminate()
+        JobPool().__init__(cpu_count())
+
     def __init__(self, pipe=0, **kwargs):
         self.pipe = pipe
         if pipe == 0:
@@ -55,6 +61,11 @@ class TestExternalJob(ExternalSeppJob):
 
 
 class Test(unittest.TestCase):
+    def tearDown(self):
+        # clean up JobPool for other unit tests
+        JobPool().terminate()
+        JobPool().__init__(cpu_count())
+
     def testSuccess(self):
         find_job = TestExternalJob()
         find_job.pattern = "."

--- a/test/unittest/testMerge.py
+++ b/test/unittest/testMerge.py
@@ -5,17 +5,21 @@ Created on Nov 20, 2012
 '''
 import unittest
 from sepp.jobs import MergeJsonJob
+from sepp.scheduler import JobPool
+from multiprocessing import cpu_count
 import sys
 import os.path
 from sepp.filemgr import get_data_path
 import sepp.config
-import logging
 from argparse import Namespace
 
 
-logging.disable(logging.INFO)
-
 class Test(unittest.TestCase):
+    def tearDown(self):
+        # clean up JobPool for other unit tests
+        JobPool().terminate()
+        JobPool().__init__(cpu_count())
+
     def testMerge(self):
         sys.argv = [sys.argv[0]]
         stdindata = open(get_data_path("tmp/tempmerge")).read()

--- a/test/unittest/testMerge.py
+++ b/test/unittest/testMerge.py
@@ -8,12 +8,21 @@ from sepp.jobs import MergeJsonJob
 import sys
 import os.path
 from sepp.filemgr import get_data_path
+import sepp.config
+import logging
+from argparse import Namespace
 
+
+logging.disable(logging.INFO)
 
 class Test(unittest.TestCase):
     def testMerge(self):
         sys.argv = [sys.argv[0]]
         stdindata = open(get_data_path("tmp/tempmerge")).read()
+
+        # write path of seppJsonMerger.jar into configuration
+        setattr(sepp.config.options(), 'jsonmerger', Namespace(
+            path=get_data_path("../../../tools/merge/seppJsonMerger.jar")))
         mergeJsonJob = MergeJsonJob()
         mergeJsonJob.setup(stdindata.replace(
             'data/tmp/pplacer.extended',

--- a/test/unittest/testSepp.py
+++ b/test/unittest/testSepp.py
@@ -9,6 +9,8 @@ import shutil
 import unittest
 import sepp
 from sepp.filemgr import get_data_path
+import platform
+from argparse import Namespace
 
 from sepp.exhaustive import ExhaustiveAlgorithm
 sepp._DEBUG = True
@@ -32,6 +34,14 @@ class Test(unittest.TestCase):
             get_data_path(
                 "q2-fragment-insertion/reference_phylogeny_tiny.nwk"), "r")
         self.x.options.outdir = tempfile.mkdtemp()
+
+        suff_bit = "-64" if sys.maxsize > 2**32 else "-32"
+        if platform.system() == 'Darwin':
+            suff_bit = ""
+        for prog in ['hmmalign', 'hmmbuild', 'hmmsearch', 'pplacer']:
+            setattr(self.x.options, prog, Namespace(
+                path=get_data_path("../../../tools/bundled/%s/%s%s" % (
+                    platform.system(), prog, suff_bit))))
 
     def tearDown(self):
         self.x.options.alignment_file.close()

--- a/test/unittest/testSepp.py
+++ b/test/unittest/testSepp.py
@@ -3,6 +3,7 @@ Created on June 14, 2018
 
 @author: Stefan.M.Janssen@gmail.com
 '''
+import sys
 import tempfile
 import shutil
 import unittest
@@ -17,6 +18,8 @@ class Test(unittest.TestCase):
     x = None
 
     def setUp(self):
+        # ensure necessary settings are made
+        sys.argv = [sys.argv[0], "-c", get_data_path("configs/test2.config")]
         self.x = ExhaustiveAlgorithm()
         self.x.options.alignment_file = open(
             get_data_path(


### PR DESCRIPTION
For coverage analysis, we need to run all unit tests in one instance.
Unfortunately, not all tests did clean up correctly after execution. This caused issues with the singletons JobPool and options, due to different numbers of requested CPUs.