### PR TITLE
pin coveralls version

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,1 +1,1 @@
-coveralls
+coveralls==1.8.2

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -112,7 +112,8 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
         if (options().molecule == 'amino'):
             moleculeType = 'protein'
         pastaalignJob.setup(backbone, options().backbone_size,
-                            moleculeType, options().cpu, **vars(options().pasta))
+                            moleculeType, options().cpu,
+                            **vars(options().pasta))
         pastaalignJob.run()
         (a_file, t_file) = pastaalignJob.read_results()
 

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,8 @@ class ConfigUPP(ConfigSepp):
         for l2 in c:
             l2 = l2.replace("~", self.get_tools_dest())
             d.write(l2)
-        d.write('\n[pasta]\npath=run_pasta.py\nuser_options= --max-mem-mb=2000')
+        d.write(('\n[pasta]\n'
+                 'path=run_pasta.py\nuser_options= --max-mem-mb=2000'))
         d.close()
 
 


### PR DESCRIPTION
Looks like we are using an outdated command in .travis.yaml https://github.com/smirarab/sepp/blob/00b519d9e242c21df8efeeb0c4d8c208ab551d5d/.travis.yml#L32 to call coveralls.
This is a duct tape fix, because I simply pin coveralls to the latest version known to succeed, even if there are never versions available.
You should look into this and better fix the offending command than to pin the version - however, this is quick but dirty and does the trick. 