### PR TITLE
-M option new functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Version 4.5.2:
+    * New -M functionality
 * Version 4.5.1:
     * fix small issues (broken links, etc.) in 4.5.0
 * Version 4.5.0:

--- a/sepp/__init__.py
+++ b/sepp/__init__.py
@@ -27,7 +27,7 @@ __all__ = ['algorithm', 'alignment', 'backtranslate',
            'jobs', 'math_utils', 'problem', 'scheduler',
            'scratch', 'tree', 'get_logger', 'is_temp_kept', 'version']
 
-version = "4.5.1"
+version = "4.5.2"
 _DEBUG = ("SEPP_DEBUG" in os.environ) and \
     (os.environ["SEPP_DEBUG"].lower() == "true")
 

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -73,12 +73,13 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
         fragments = MutableAlignment()
         if options().median_full_length is not None \
                 or options().full_length_range is not None:
-            if -1 <= options().median_full_length < 0:
+            if  options().median_full_length == -1 \
+                    or 0 < options().median_full_length < 1:
                 # for backward compatibility, -1 is mapped to 0.5 quantile.
                 if options().median_full_length == -1:
                     quantile_value = 0.5
                 else:
-                    quantile_value = -options().median_full_length
+                    quantile_value = options().median_full_length
                 seq_lengths = sorted(
                     [len(seq) for seq in list(sequences.values())])
                 lengths = len(seq_lengths)
@@ -414,8 +415,8 @@ def augment_parser():
         help="Consider all fragments that are 25%% longer or shorter than N "
              "to be excluded from the backbone.  If value is -1, then UPP will"
              " use the median of the sequences as the median full length. "
-             "Use -1 < N < 0 for UPP to use quartiles. e.g.  -0.25 for the first "
-             " quartile and -0.75 for the third quartile. "
+             "Use 0 < N < 1 for UPP to use quartiles. e.g.  0.25 for the first "
+             " quartile and 0.75 for the third quartile. "
              "[default: None]")
     decompGroup.add_argument(
         "-T", "--backbone_threshold", type=float,

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -71,8 +71,9 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
         sequences.read_file_object(self.options.sequence_file)
         sequences.degap()
         fragments = MutableAlignment()
-        if (options().median_full_length is not None):
-            if (-1 <= options().median_full_length < 0):
+        if options().median_full_length is not None \
+                or options().full_length_range is not None:
+            if -1 <= options().median_full_length < 0:
                 # for backward compatibility, -1 is mapped to 0.5 quantile.
                 if options().median_full_length == -1:
                     quantile_value = 0.5

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from setuptools import find_packages
 from distutils.core import setup, Command
 
 use_setuptools(version="0.6.24")
-version = "4.5.1"
+version = "4.5.2"
 
 
 def get_tools_dir(where):


### PR DESCRIPTION
when -M value is between -1 and 0, it indicates the quantile value. For backward compatibility, -1 still maps to 50% quantile, which is median.