### PR TITLE
Fixed dendropy to the compatible version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# golob/sepp:4.5.1
+
+
+FROM --platform=amd64 debian:bullseye-slim
+
+RUN export TZ=Etc/UTC
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get update && \
+apt-get -y install tzdata && \
+apt-get install -y \
+    openjdk-11-jre \
+    pigz \
+    python3-pip \
+&& apt-get clean \
+&& apt-get purge \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD . /src/
+
+RUN cd /src/ && \
+python3 setup.py config && \
+python3 setup.py install && \
+mv /src/test /root/test/ && \
+cd /root/ && rm -r /src/
+
+WORKDIR /root/
+
+ENTRYPOINT [ "/usr/local/bin/run_sepp.py" ] 

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ setup(name="sepp",
       author_email="smirarab@gmail.com, namphuon@cs.utah.edu",
 
       license="General Public License (GPL)",
-      install_requires=["dendropy >= 4.0.0"],
+      install_requires=["dendropy == 4.5.2"],
       provides=["sepp"],
       scripts=["run_sepp.py", 'run_upp.py', "split_sequences.py"],
       cmdclass={"config": ConfigSepp, "upp": ConfigUPP},


### PR DESCRIPTION
Greetings! I have made a small change to setup.py to fix dendropy to the compatible version.
This should close issue#125 "Dendropy v4.6.0 causing SEPP to break".



