### PR TITLE
Fix new installation routine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Repository = "https://github.com/smirarab/sepp"
 Issues = "https://github.com/smirarab/sepp/issues"
 
 [project.scripts]
-"run_sepp.py" = "sepp.exhaustive.ExhaustiveAlgorithm:run"
+"run_sepp.py" = "sepp.exhaustive:main"
 "run_upp.py" = "sepp.exhaustive_upp:main"
 "split_sequences.py" = "split_sequences:main"
 config_sepp = "sepp.install.configure:config_sepp"

--- a/sepp/config.py
+++ b/sepp/config.py
@@ -46,11 +46,16 @@ import os.path
 from multiprocessing import cpu_count
 from sepp import scheduler
 import random
+import importlib.metadata
 
 _LOG = get_logger(__name__)
 
-root_p = open(os.path.join(os.path.split(
-    os.path.split(__file__)[0])[0], "home.path")).readlines()[0].strip()
+# obtain filepath of original sepp source directory, which is
+# stored in a file "home.path", which is located in the site-package
+# installation
+fp_home = os.path.join(
+    importlib.metadata.distribution("sepp")._path, "home.path")
+root_p = open(fp_home).readlines()[0].strip()
 print("root_p='%s'" % root_p)
 main_config_path = os.path.join(root_p, "main.config")
 

--- a/sepp/exhaustive.py
+++ b/sepp/exhaustive.py
@@ -505,8 +505,10 @@ class ExhaustiveAlgorithm(AbstractAlgorithm):
             for ap in p.children:
                 JobPool().enqueue_job(ap.jobs["hmmbuild"])
 
+
 def main():
     ExhaustiveAlgorithm().run()
+
 
 if __name__ == '__main__':
     main()

--- a/sepp/exhaustive.py
+++ b/sepp/exhaustive.py
@@ -505,6 +505,8 @@ class ExhaustiveAlgorithm(AbstractAlgorithm):
             for ap in p.children:
                 JobPool().enqueue_job(ap.jobs["hmmbuild"])
 
+def main():
+    ExhaustiveAlgorithm().run()
 
 if __name__ == '__main__':
-    ExhaustiveAlgorithm().run()
+    main()

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -382,8 +382,12 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
 
 
 def augment_parser():
-    root_p = open(os.path.join(os.path.split(
-        os.path.split(__file__)[0])[0], "home.path")).readlines()[0].strip()
+    # obtain filepath of original sepp source directory, which is
+    # stored in a file "home.path", which is located in the site-package
+    # installation
+    fp_home = os.path.join(
+        importlib.metadata.distribution("sepp")._path, "home.path")
+    root_p = open(fp_home).readlines()[0].strip()
     upp_config_path = os.path.join(root_p, "upp.config")
     sepp.config.set_main_config_path(upp_config_path)
     parser = sepp.config.get_parser()

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -8,6 +8,7 @@ import random
 import argparse
 import os
 import shutil
+import importlib.metadata
 from math import floor
 from sepp import get_logger
 from sepp.alignment import MutableAlignment, ExtendedAlignment, _write_fasta

--- a/sepp/install/configure.py
+++ b/sepp/install/configure.py
@@ -54,6 +54,18 @@ class ConfigSepp(Command):
         target_dir = dist._path
         shutil.copy(fp_home_path, os.path.join(target_dir, fp_home_path))
 
+        # update the softlinks (run_sepp.py and run_upp.py) in
+        # ./sepp-package/sepp/ such that they point to
+        # the python "binaries" installed in PREFIX/bin/
+        for binname in ['run_sepp.py', 'run_upp.py']:
+            fp_link = os.path.abspath(os.path.join(
+                self.basepath, '..', 'sepp-package', 'sepp', binname))
+            fp_link_target = os.path.abspath(os.path.join(
+                sys.prefix, 'bin', binname))
+            if os.path.lexists(fp_link):
+                os.unlink(fp_link)
+            os.symlink(fp_link_target, fp_link)
+
     def get_tools_dest(self):
         return os.path.join(self.basepath, "bundled-v%s" % self.version)
 

--- a/sepp/install/configure.py
+++ b/sepp/install/configure.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import sys
-import site
 
 import shutil
 from setuptools import Command, Distribution

--- a/sepp/install/configure.py
+++ b/sepp/install/configure.py
@@ -5,6 +5,7 @@ import site
 
 import shutil
 from setuptools import Command, Distribution
+import importlib.metadata
 import argparse
 from sepp import version
 
@@ -49,9 +50,8 @@ class ConfigSepp(Command):
             fo.close()
 
         # copy created home.path file to site-packages directory
-        target_dir = site.getsitepackages()[0]
-        if not self.contained:
-            target_dir = site.getusersitepackages()
+        dist = importlib.metadata.distribution("sepp")
+        target_dir = dist._path
         shutil.copy(fp_home_path, os.path.join(target_dir, fp_home_path))
 
     def get_tools_dest(self):


### PR DESCRIPTION
Two issues with novel pip install exist:
1. the `home.path` file was not copied into the module sub-directory, but the `site-packages` dir
2. the symlinks in `./sepp-package/sepp` to `run_sepp.py` and `run_upp.py` are broken, because these files are no longer explicitly located in the root directory, but get created during `pip install` in the $PREFIX/bin/ dir
3. the auto-generated `run_sepp.py` did not work without having a `main()` method directly accessible in `./sepp/exhaustive.py`, which I added here

The `config_sepp.py` script, which calls the `initpath` method of `./sepp/install/configure.py` should now handle both cases.