### PR TITLE
report about home.path mechanism during configuration

### DIFF
--- a/sepp/install/configure.py
+++ b/sepp/install/configure.py
@@ -52,6 +52,9 @@ class ConfigSepp(Command):
         dist = importlib.metadata.distribution("sepp")
         target_dir = dist._path
         shutil.copy(fp_home_path, os.path.join(target_dir, fp_home_path))
+        print(("\nCreating home.path file at %s to point to sepp original"
+               "installation path, which is at %s") % (
+                   os.path.join(target_dir, fp_home_path), self.basepath))
 
         # update the softlinks (run_sepp.py and run_upp.py) in
         # ./sepp-package/sepp/ such that they point to


### PR DESCRIPTION
be more verbose about location and content of home.path configuration file when executing `config_sepp` or `config_upp`