### PR TITLE
addressing 'Unintended directory rename'

### DIFF
--- a/sepp/jobs.py
+++ b/sepp/jobs.py
@@ -541,7 +541,7 @@ class PplacerJob(ExternalSeppJob):
                 "pplacer.full.extended.%d." % i, subproblem, ".fasta")
         self.out_file = os.path.join(
             sepp.filemgr.tempdir_for_subproblem(subproblem),
-            os.path.splitext(self.extended_alignment_file)[0] + "jplace")
+            os.path.splitext(self.extended_alignment_file)[0] + ".jplace")
         assert isinstance(subproblem.subtree, PhylogeneticTree)
         subproblem.subtree.write_newick_to_path(self.tree_file,)
 

--- a/sepp/jobs.py
+++ b/sepp/jobs.py
@@ -541,7 +541,7 @@ class PplacerJob(ExternalSeppJob):
                 "pplacer.full.extended.%d." % i, subproblem, ".fasta")
         self.out_file = os.path.join(
             sepp.filemgr.tempdir_for_subproblem(subproblem),
-            self.extended_alignment_file.replace("fasta", "jplac_e"))
+            os.path.splitext(self.extended_alignment_file)[0] + "jplace")
         assert isinstance(subproblem.subtree, PhylogeneticTree)
         subproblem.subtree.write_newick_to_path(self.tree_file,)
 

--- a/sepp/jobs.py
+++ b/sepp/jobs.py
@@ -541,7 +541,7 @@ class PplacerJob(ExternalSeppJob):
                 "pplacer.full.extended.%d." % i, subproblem, ".fasta")
         self.out_file = os.path.join(
             sepp.filemgr.tempdir_for_subproblem(subproblem),
-            self.extended_alignment_file.replace("fasta", "jplace"))
+            self.extended_alignment_file.replace("fasta", "jplac_e"))
         assert isinstance(subproblem.subtree, PhylogeneticTree)
         subproblem.subtree.write_newick_to_path(self.tree_file,)
 


### PR DESCRIPTION
Addressing issue #143
Instead of "blindly" replacing each occurrence of "fasta" with "jplace", we now chop of the file extension and append ".jplace" 